### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Smartyparse is under development as part of the [Muse protocol](https://github.c
     + http://www.dragonwins.com/domains/getteched/bmp/bmpfileformat.htm
 + Move/mirror documentation to readthedocs
 + Add padding generation method (in addition to constant byte)
-+ Add pip version badge: ```[![PyPi version](https://pypip.in/v/$REPO/badge.png)](https://github.com/Muterra/py_smartyparse)``` above.
++ Add pip version badge: ```[![PyPi version](https://img.shields.io/pypi/v/.svg$REPO/badge.png)](https://github.com/Muterra/py_smartyparse)``` above.
 + Support bit orientation
 + Support endianness of binary blobs (aka transforming from little to big)
 + Support memoization of static SmartyParsers for extremely performant parsing


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20smartyparse))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `smartyparse`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.